### PR TITLE
specify header_mappings_dir to avoid flattening header files

### DIFF
--- a/filter_audio.podspec
+++ b/filter_audio.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.swift_version = '4.2'
   s.exclude_files = 'test/*'
   s.source_files = '**/*.{h,c}'
+  s.header_mappings_dir = './'
   s.public_header_files = '**/*.h'
   s.pod_target_xcconfig = {'HEADER_SEARCH_PATHS' => '${SRCROOT}/**'}
   s.static_framework = true


### PR DESCRIPTION
should fix an issue like
```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "Headers/filter_audio-umbrella.h"
        ^
/Library/Developer/Xcode/DerivedData/SpokeStack-diftcezyxfafpedlpsyawmgpvhqk/Build/Products/Debug-iphonesimulator/filter_audio/filter_audio.framework/Headers/filter_audio-umbrella.h:15:9: note: in file included from /Library/Developer/Xcode/DerivedData/SpokeStack-diftcezyxfafpedlpsyawmgpvhqk/Build/Products/Debug-iphonesimulator/filter_audio/filter_audio.framework/Headers/filter_audio-umbrella.h:15:
#import "aec_core_internal.h"
        ^
/Library/Developer/Xcode/DerivedData/SpokeStack-diftcezyxfafpedlpsyawmgpvhqk/Build/Products/Debug-iphonesimulator/filter_audio/filter_audio.framework/Headers/aec_core_internal.h:17:10: error: '../other/ring_buffer.h' file not found
#include "../other/ring_buffer.h"
         ^
/spokestack-ios/SpokeStack/WebRTCVAD.swift:10:8: error: could not build Objective-C module 'filter_audio'
import filter_audio
```